### PR TITLE
Adding potential CPAN perl module dependency on File::Type to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ tophat-2.1.1.Linux_x86_64
 tophat2
 trim (http://graphics.med.yale.edu/trim/)
 ```
+### Install Perl modules (if needed)
+```
+File::Type (https://metacpan.org/pod/File::Type)
+```
 
 ### Install .pl and r files
 ```


### PR DESCRIPTION
Was helping a science user on an Ubuntu 18.04 LTS system get this software and external dependencies installed and realized the native Perl environment did not have File::Type module installed. It was an easy install via CPAN. Added a note to the README.md file if this would be helpful for others